### PR TITLE
AbstractAreaクラス追加

### DIFF
--- a/AbstractArea.pde
+++ b/AbstractArea.pde
@@ -1,0 +1,14 @@
+abstract class AbstractArea {
+  int posX;
+  int posY;
+  int tate;
+  int yoko;
+  AbstractArea(int posX, int posY, int yoko, int tate) {
+    this.posX = posX;
+    this.posY = posY;
+    this.yoko = yoko;
+    this.tate = tate;
+  }
+  abstract void draw();
+
+}


### PR DESCRIPTION
すべての種類のAreaクラスが継承するAbstractAreaクラスを追加した.
エリアの左上座標(poX, posY)と縦幅(tate)，横幅(yoko)をフィールドに持つ
コンストラクタではすべての値の初期化をコンストラクタ引数を用いて行う．
抽象メソッドとしてdraw()を持つ